### PR TITLE
Replace wmic with PowerShell

### DIFF
--- a/Natsurainko.FluentCore/Utils/MemoryUtils.cs
+++ b/Natsurainko.FluentCore/Utils/MemoryUtils.cs
@@ -12,8 +12,8 @@ public static class MemoryUtils
     {
         using var process = Process.Start(new ProcessStartInfo()
         {
-            FileName = "wmic",
-            Arguments = "OS get FreePhysicalMemory,TotalVisibleMemorySize /Value",
+            FileName = "powershell",
+            Arguments = "-NoLogo -NonInteractive -Command \"Get-CIMInstance Win32_OperatingSystem | Select FreePhysicalMemory,TotalVisibleMemorySize | Format-List\"",
             RedirectStandardOutput = true,
             CreateNoWindow = true,
         });
@@ -21,8 +21,8 @@ public static class MemoryUtils
         process.WaitForExit();
 
         var lines = process.StandardOutput.ReadToEnd().Trim().Split("\n");
-        var freeMemoryParts = lines[0].Split("=", StringSplitOptions.RemoveEmptyEntries);
-        var totalMemoryParts = lines[1].Split("=", StringSplitOptions.RemoveEmptyEntries);
+        var freeMemoryParts = lines[0].Split(":", StringSplitOptions.RemoveEmptyEntries);
+        var totalMemoryParts = lines[1].Split(":", StringSplitOptions.RemoveEmptyEntries);
 
         var total = Math.Round(double.Parse(totalMemoryParts[1]) / 1024, 0);
         var free = Math.Round(double.Parse(freeMemoryParts[1]) / 1024, 0);


### PR DESCRIPTION
Since WMIC has been deprecated by Microsoft and moved to optional features, you can't use the launcher properly if you remove WMIC, so it was replaced with Windows PowerShell.
由于 WMIC 已经被微软弃用，并移动到可选功能中，如果移除 WMIC 就无法正常使用启动器，所以就把 WMIC 替换为 Windows PowerShell。

[WMI 命令行 (WMIC) 实用程序 - Win32 apps | Microsoft Learn](https://learn.microsoft.com/zh-cn/windows/win32/wmisdk/wmic)

<img width="655" alt="Snipaste_2023-10-09_21-43-24" src="https://github.com/Xcube-Studio/Natsurainko.FluentCore/assets/34326561/9ebb25e0-e7a1-411f-8a8e-006c5bd240c0">
<img width="704" alt="Snipaste_2023-10-09_21-49-25" src="https://github.com/Xcube-Studio/Natsurainko.FluentCore/assets/34326561/1ba0874b-bd90-43ac-b01f-2b67eaa6c291">

I tested this method on Windows 11 22H2 and Windows 10 22H2.
我在 Windows 11 22H2 和 Windows 10 22H2 上面测试过这个方法。

[Natsurainko.FluentCore/ConsoleApp1/Program.cs at test · KoakiMiku/Natsurainko.FluentCore](https://github.com/KoakiMiku/Natsurainko.FluentCore/blob/test/ConsoleApp1/Program.cs)

<img width="780" alt="Snipaste_2023-10-09_21-36-19" src="https://github.com/Xcube-Studio/Natsurainko.FluentCore/assets/34326561/060cf48f-f001-4863-8c22-0c130fb40df9">
<img width="748" alt="Snipaste_2023-10-09_21-33-22" src="https://github.com/Xcube-Studio/Natsurainko.FluentCore/assets/34326561/257d93cf-b26c-4a00-8bea-6fce09f0ac0c">
